### PR TITLE
remove return model

### DIFF
--- a/src/domain/repositories/user.js
+++ b/src/domain/repositories/user.js
@@ -1,9 +1,6 @@
 module.exports = app => {
   const UserModel = app.domain.datasource.models.user
   class UserRepository {
-    static getModel () {
-      return UserModel
-    }
 
     static async getUserAuth (user, done) {
       let response = null


### PR DESCRIPTION
remove get model, because controllers and another classes should not call this model directly.